### PR TITLE
feat: add ci testing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create docker network
         run: docker network create ci-default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ["8.3", "8.4"]
+        drupal-version: ["10.6", "11.3"] 
+
+    name: PHP ${{ matrix.php-versions }} | Drupal ${{ matrix.drupal-version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create docker network
+        run: docker network create ci-default
+
+      - name: Start chromedriver
+        run: |-
+          docker run -d \
+            --name chromedriver \
+            --network ci-default \
+            drupalci/webdriver-chromedriver:production \
+            chromedriver --log-path=/dev/null --verbose --allowed-ips= --allowed-origins=*
+
+      - name: PHPUnit tests
+        run: |
+          docker run \
+            --rm \
+            --name drupal \
+            --hostname drupal \
+            --volume $(pwd):/var/www/drupal/web/modules/contrib/$ENABLE_MODULES:ro \
+            --env ENABLE_MODULES \
+            --network ci-default \
+           ghcr.io/islandora/ci:${{ matrix.drupal-version }}-php${{ matrix.php-versions }}
+        env:
+          ENABLE_MODULES: media_fits


### PR DESCRIPTION
# Description
This PR adds continuous integration (CI) workflow which uses matrix for testing multiple PHP and Drupal versions and sets up a Docker-based test environment.

# Changes
- Added a new `.github/workflows/ci.yml` file that defines a matrix CI workflow to test against multiple PHP (`8.3`, `8.4`) and Drupal (`10.6`, `11.3`) versions using Docker containers.
- The new workflow runs on pushes and pull requests to the `main` branch, as well as via manual dispatch.