### PR TITLE
refactor/phpcs-ignore-comments

### DIFF
--- a/media_fits.module
+++ b/media_fits.module
@@ -5,9 +5,6 @@
  * Contains fits.module.
  */
 
-// phpcs:disable Drupal.Files.LineLength.TooLong
-// phpcs:disable Drupal.NamingConventions.ValidFunctionName.InvalidPrefix
-
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\media\Entity\Media;
@@ -47,7 +44,7 @@ function media_fits_media_insert(EntityInterface $entity) {
   // Only extract Fits for File level only.
   if ('Media' === $entity->getEntityType()->getLabel()->getUntranslatedString()
       && 1 === \Drupal::config('media_fits.fitsconfig')->get('fits-extract-ingesting')) {
-    execute_media_fits_action($entity);
+    media_fits_execute_media_fits_action($entity);
   }
 }
 
@@ -57,7 +54,8 @@ function media_fits_media_insert(EntityInterface $entity) {
 /*function media_fits_media_update(EntityInterface $entity) {
 // Only extract Fits for File level only.
 if ('Media' === $entity->getEntityType()->getLabel()->getUntranslatedString()
-&& 1 === \Drupal::config('media_fits.fitsconfig')->get('fits-extract-ingesting')) {
+&& 1 === \Drupal::config('media_fits.fitsconfig')
+->get('fits-extract-ingesting')) {
 
 $media = Media::load($entity->id());
 $source_field_name = $media->getSource()->getConfiguration()['source_field'];
@@ -66,7 +64,8 @@ $current_file_id = $media->get($source_field_name)->target_id;
 $previous_revision_id = $media->getRevisionId() - 1;
 $previous_revision = \Drupal::entityTypeManager()->getStorage('media')->loadRevision($previous_revision_id);
 
-if (isset($source_field_name) && (isset($previous_revision) && $previous_revision->hasField($source_field_name))) {
+if (isset($source_field_name) && (isset($previous_revision) &&
+$previous_revision->hasField($source_field_name))) {
 $previous_file_id = $previous_revision->get($source_field_name)->target_id;
 } else {
 $previous_file_id = null; // or any other default value or action
@@ -74,7 +73,7 @@ $previous_file_id = null; // or any other default value or action
 
 if ($current_file_id !== $previous_file_id) {
 // A new file ID was generated.
-execute_media_fits_action($entity);
+media_fits_execute_media_fits_action($entity);
 }
 }
 }*/
@@ -82,7 +81,7 @@ execute_media_fits_action($entity);
 /**
  * Shared function call for execute Fits Action.
  */
-function execute_media_fits_action(EntityInterface $entity) {
+function media_fits_execute_media_fits_action(EntityInterface $entity) {
   // Fix warning when Config form hasn't been setup.
   $config = \Drupal::config('media_fits.fitsconfig');
   if (!isset($config) || empty($config->get('fits-advancedqueue_id'))) {
@@ -91,39 +90,4 @@ function execute_media_fits_action(EntityInterface $entity) {
   $media = Media::load($entity->id());
   $utils = \Drupal::service('media_fits.context_utils');
   $utils->executeFileReactions('\Drupal\media_fits\Plugin\ContextReaction\MediaFitsReaction', $media);
-}
-
-if (!function_exists('print_log')) {
-
-  /**
-   * Debug function: display any variable to error log.
-   */
-  function print_log($thing) {
-    error_log(print_r($thing, TRUE), 0);
-  }
-
-}
-
-if (!function_exists('logging')) {
-
-  /**
-   * Debug function: display any variable to current webpage.
-   */
-  function logging($thing) {
-    echo '<pre>';
-    print_r($thing);
-    echo '</pre>';
-  }
-
-}
-
-if (!function_exists('drupal_log')) {
-
-  /**
-   * Debug function: display any variable to drupal Reports Log messages.
-   */
-  function drupal_log($msg) {
-    \Drupal::logger(basename(__FILE__, '.module'))->error($msg);
-  }
-
 }

--- a/src/Form/MediaFitsConfigForm.php
+++ b/src/Form/MediaFitsConfigForm.php
@@ -1,17 +1,63 @@
 <?php
 
-// phpcs:disable DrupalPractice.General.OptionsT.TforValue
-// phpcs:disable DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
-
 namespace Drupal\media_fits\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class MediaFitsConfigForm definition.
  */
 class MediaFitsConfigForm extends ConfigFormBase {
+
+  /**
+   * The entity field manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a MediaFitsConfigForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    EntityFieldManagerInterface $entity_field_manager,
+    EntityTypeManagerInterface $entity_type_manager,
+  ) {
+    parent::__construct($config_factory);
+    $this->entityFieldManager = $entity_field_manager;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('entity_field.manager'),
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -51,9 +97,9 @@ class MediaFitsConfigForm extends ConfigFormBase {
       '#type' => 'select',
       '#title' => 'Select Fits method:',
       '#options' => [
-        0 => '-- Select --',
-        'remote' => 'FITS Web Service',
-        'local' => 'FITS from the command-line',
+        0 => $this->t('-- Select --'),
+        'remote' => $this->t('FITS Web Service'),
+        'local' => $this->t('FITS from the command-line'),
       ],
       '#required' => TRUE,
       '#ajax' => [
@@ -100,7 +146,7 @@ class MediaFitsConfigForm extends ConfigFormBase {
     ];
 
     $queues = ['0' => "-- Select --"];
-    $queues = array_merge($queues, \Drupal::entityQuery('advancedqueue_queue')->execute());
+    $queues = array_merge($queues, $this->entityTypeManager->getStorage('advancedqueue_queue')->getQuery()->execute());
     $form['container']['fits-services-config']['op-config']['advancedqueue-id'] = [
       '#type' => 'select',
       '#name' => 'advancedqueue-id',
@@ -137,7 +183,7 @@ class MediaFitsConfigForm extends ConfigFormBase {
     ];
 
     // Select default fits fields.
-    $field_map = \Drupal::service('entity_field.manager')->getFieldMap();
+    $field_map = $this->entityFieldManager->getFieldMap();
     $node_field_map = $field_map['file'];
     $fields = array_keys($node_field_map);
     $fits_fields = [];
@@ -189,7 +235,7 @@ class MediaFitsConfigForm extends ConfigFormBase {
    * Query existing File types.
    */
   public function getFileTypes() {
-    $contentTypes = \Drupal::service('entity_type.manager')->getStorage('file_type')->loadMultiple();
+    $contentTypes = $this->entityTypeManager->getStorage('file_type')->loadMultiple();
     $types = [];
     foreach ($contentTypes as $contentType) {
       $types[$contentType->id()] = $contentType->label();

--- a/src/Plugin/AdvancedQueue/JobType/MediaFitsJob.php
+++ b/src/Plugin/AdvancedQueue/JobType/MediaFitsJob.php
@@ -54,8 +54,6 @@ class MediaFitsJob extends JobTypeBase {
    */
   public function extractFits($media = NULL) {
     /** @var \Drupal\media\MediaInterface $media */
-    // phpcs:ignore -- Unused variable $config.
-    $config = \Drupal::config('media_fits.fitsconfig');
     $report = "";
     $sucess = TRUE;
     if (!isset($media)) {


### PR DESCRIPTION
# Description
This PR refactors the codebase by renaming method names, deleting unused variables and methods, implementing dependency injection, and adding translatibility to options.

# Changes
- `media_fits.module`: Delete unused utility functions and rename method to use Drupal module file naming convention.
-  `src/Form/MediaFitsConfigForm.php`: Add translation calls and implement dependency injection.
-  `src/Plugin/AdvancedQueue/JobType/MediaFitsJob.php`: Delete unused variable.